### PR TITLE
Add a safer settings / localStorage check.

### DIFF
--- a/port.js
+++ b/port.js
@@ -27,7 +27,15 @@ SAFARI = (typeof safari !== "undefined");
 LEGACY_SAFARI = SAFARI && (navigator.appVersion.match(/\sSafari\/(\d+)\./) || [null,0])[1] < 534;
 
 // "localStorage" gets cleared too often in Safari to rely on.
-options = SAFARI ? safari.extension.settings : localStorage;
+if (SAFARI) {
+  options = safari.extension.settings;
+} else {
+  try {
+    options = localStorage;
+  } catch(e) {
+    options = {}; // fallback if localStorage is unavailable
+  }
+}
 
 if (SAFARI) {
 


### PR DESCRIPTION
This keeps blowing up in my current Disconnect extension in Chrome (Version `5.13.0`). When localStorage is not available a JavaScript error is thrown:

```
Uncaught SecurityError: Failed to read the 'localStorage'
property from 'Window': Access is denied for this document.
```

I'm not sure how to properly fall back on options, but without testing the extension in its entirety this is the best I have for now.

![screen shot 2014-02-26 at 8 28 25 pm](https://f.cloud.github.com/assets/1817/2279214/ba05cf34-9f67-11e3-8a1f-f5efcd2c5fcc.png)

![screen shot 2014-02-26 at 8 28 48 pm](https://f.cloud.github.com/assets/1817/2279215/bd6c8c30-9f67-11e3-9ee9-48afb49cd442.png)
